### PR TITLE
MPU-9250 tests, but actually working at 200 Hz this time.

### DIFF
--- a/modified libraries/Adafruit_FRAM_I2C/Adafruit_FRAM_I2C.cpp
+++ b/modified libraries/Adafruit_FRAM_I2C/Adafruit_FRAM_I2C.cpp
@@ -1,0 +1,169 @@
+/**************************************************************************/
+/*!
+    @file     Adafruit_FRAM_I2C.cpp
+    @author   KTOWN (Adafruit Industries)
+    @license  BSD (see license.txt)
+
+    Driver for the Adafruit I2C FRAM breakout.
+
+    Adafruit invests time and resources providing this open source code,
+    please support Adafruit and open-source hardware by purchasing
+    products from Adafruit!
+
+    @section  HISTORY
+
+    v1.0 - First release
+*/
+/**************************************************************************/
+//#include <avr/pgmspace.h>
+//#include <util/delay.h>
+#include <stdlib.h>
+#include <math.h>
+
+#include "Adafruit_FRAM_I2C.h"
+
+/*========================================================================*/
+/*                            CONSTRUCTORS                                */
+/*========================================================================*/
+
+/**************************************************************************/
+/*!
+    Constructor
+*/
+/**************************************************************************/
+Adafruit_FRAM_I2C::Adafruit_FRAM_I2C(void) 
+{
+  _framInitialised = false;
+}
+
+/*========================================================================*/
+/*                           PUBLIC FUNCTIONS                             */
+/*========================================================================*/
+
+/**************************************************************************/
+/*!
+    Initializes I2C and configures the chip (call this function before
+    doing anything else)
+*/
+/**************************************************************************/
+boolean Adafruit_FRAM_I2C::begin(uint8_t addr) 
+{
+  i2c_addr = addr;
+  // Wire.begin();
+  
+  /* Make sure we're actually connected */
+  uint16_t manufID, prodID;
+  getDeviceID(&manufID, &prodID);
+  if (manufID != 0x00A)
+  {
+    Serial.print("Unexpected Manufacturer ID: 0x");
+    Serial.println(manufID, HEX);
+    return false;
+  }
+  if (prodID != 0x510)
+  {
+    Serial.print("Unexpected Product ID: 0x");
+    Serial.println(prodID, HEX);
+    return false;
+  }
+
+  /* Everything seems to be properly initialised and connected */
+  _framInitialised = true;
+
+  return true;
+}
+
+/**************************************************************************/
+/*!
+    @brief  Writes a byte at the specific FRAM address
+    
+    @params[in] i2cAddr
+                The I2C address of the FRAM memory chip (1010+A2+A1+A0)
+    @params[in] framAddr
+                The 16-bit address to write to in FRAM memory
+    @params[in] i2cAddr
+                The 8-bit value to write at framAddr
+*/
+/**************************************************************************/
+void Adafruit_FRAM_I2C::write8 (uint16_t framAddr, uint8_t value)
+{
+  Wire.beginTransmission(i2c_addr);
+  Wire.write(framAddr >> 8);
+  Wire.write(framAddr & 0xFF);
+  Wire.write(value);
+  Wire.endTransmission();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reads an 8 bit value from the specified FRAM address
+
+    @params[in] i2cAddr
+                The I2C address of the FRAM memory chip (1010+A2+A1+A0)
+    @params[in] framAddr
+                The 16-bit address to read from in FRAM memory
+
+    @returns    The 8-bit value retrieved at framAddr
+*/
+/**************************************************************************/
+uint8_t Adafruit_FRAM_I2C::read8 (uint16_t framAddr)
+{
+  Wire.beginTransmission(i2c_addr);
+  Wire.write(framAddr >> 8);
+  Wire.write(framAddr & 0xFF);
+  Wire.endTransmission();
+
+  Wire.requestFrom(i2c_addr, (uint8_t)1);
+  
+  return Wire.read();
+}
+
+/**************************************************************************/
+/*!
+    @brief  Reads the Manufacturer ID and the Product ID frm the IC
+
+    @params[out]  manufacturerID
+                  The 12-bit manufacturer ID (Fujitsu = 0x00A)
+    @params[out]  productID
+                  The memory density (bytes 11..8) and proprietary
+                  Product ID fields (bytes 7..0). Should be 0x510 for
+                  the MB85RC256V.
+*/
+/**************************************************************************/
+void Adafruit_FRAM_I2C::getDeviceID(uint16_t *manufacturerID, uint16_t *productID)
+{
+  uint8_t a[3] = { 0, 0, 0 };
+  uint8_t results;
+  
+  Wire.beginTransmission(MB85RC_SLAVE_ID >> 1);
+  Wire.write(i2c_addr << 1);
+  results = Wire.endTransmission(false);
+
+  Wire.requestFrom(MB85RC_SLAVE_ID >> 1, 3);
+  a[0] = Wire.read();
+  a[1] = Wire.read();
+  a[2] = Wire.read();
+
+  /* Shift values to separate manuf and prod IDs */
+  /* See p.10 of http://www.fujitsu.com/downloads/MICRO/fsa/pdf/products/memory/fram/MB85RC256V-DS501-00017-3v0-E.pdf */
+  *manufacturerID = (a[0] << 4) + (a[1]  >> 4);
+  *productID = ((a[1] & 0x0F) << 8) + a[2];
+}
+
+//This is a hacky mess and should be replaced by something more generalised ASAP.
+void Adafruit_FRAM_I2C::write8_begin(uint16_t framAddr)
+{
+  Wire.beginTransmission(i2c_addr);
+  Wire.write(framAddr >> 8);
+  Wire.write(framAddr & 0xFF);
+}
+
+void Adafruit_FRAM_I2C::write8_enqueue(uint8_t value)
+{
+  Wire.write(value);
+}
+
+void Adafruit_FRAM_I2C::write8_end(void)
+{
+  Wire.endTransmission();
+}

--- a/modified libraries/Adafruit_FRAM_I2C/Adafruit_FRAM_I2C.h
+++ b/modified libraries/Adafruit_FRAM_I2C/Adafruit_FRAM_I2C.h
@@ -1,0 +1,68 @@
+/**************************************************************************/
+/*! 
+    @file     Adafruit_FRAM_I2C.h
+    @author   KTOWN (Adafruit Industries)
+
+    @section LICENSE
+
+    Software License Agreement (BSD License)
+
+    Copyright (c) 2013, Adafruit Industries
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    1. Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    2. Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    3. Neither the name of the copyright holders nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+/**************************************************************************/
+#ifndef _ADAFRUIT_FRAM_I2C_H_
+#define _ADAFRUIT_FRAM_I2C_H_
+
+#if ARDUINO >= 100
+ #include <Arduino.h>
+#else
+ #include <WProgram.h>
+#endif
+
+#include <Wire.h>
+
+#define MB85RC_DEFAULT_ADDRESS        (0x50) /* 1010 + A2 + A1 + A0 = 0x50 default */
+#define MB85RC_SLAVE_ID       (0xF8)
+
+class Adafruit_FRAM_I2C {
+ public:
+  Adafruit_FRAM_I2C(void);
+  
+  boolean  begin(uint8_t addr = MB85RC_DEFAULT_ADDRESS);
+  void     write8 (uint16_t framAddr, uint8_t value);
+  uint8_t  read8  (uint16_t framAddr);
+  void     getDeviceID(uint16_t *manufacturerID, uint16_t *productID);
+  
+  void write8_begin(uint16_t framAddr);
+  void write8_enqueue(uint8_t value);
+  void write8_end(void);
+
+ private:
+  uint8_t i2c_addr;
+  boolean _framInitialised;
+};
+
+#endif

--- a/modified libraries/Adafruit_FRAM_I2C/LICENSE
+++ b/modified libraries/Adafruit_FRAM_I2C/LICENSE
@@ -1,0 +1,26 @@
+Software License Agreement (BSD License)
+
+Copyright (c) 2013, Adafruit Industries
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holders nor the
+names of its contributors may be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ''AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/modified libraries/Adafruit_FRAM_I2C/README.md
+++ b/modified libraries/Adafruit_FRAM_I2C/README.md
@@ -1,0 +1,21 @@
+#Adafruit I2C FRAM Driver #
+
+This driver is for the Adafruit I2C FRAM breakout.
+    ------> http://www.adafruit.com/products/1895
+
+## About this Driver ##
+
+These modules use I2C to communicate, 2 pins are required to  
+interface
+
+Adafruit invests time and resources providing this open source code, 
+please support Adafruit and open-source hardware by purchasing 
+products from Adafruit!
+
+Written by Kevin (KTOWN) Townsend for Adafruit Industries.
+BSD license, check license.txt for more information
+All text above must be included in any redistribution
+
+To download. click the ZIP button in the top bar, and check this tutorial
+for instructions on how to install: 
+http://learn.adafruit.com/adafruit-all-about-arduino-libraries-install-use

--- a/mpu-9250-tests.ino
+++ b/mpu-9250-tests.ino
@@ -1,0 +1,273 @@
+#include <Wire.h>
+#include <SPI.h>
+#include <MPU9250.h>
+
+/*
+ * Comment on removal of quaternionFilters.h:
+ * Sparkfun's MPU-9250 library suggests the use of an orientation estimator based on Madgwick's algorithm.
+ * However, I strongly suspect that it is useless for rocketry without extensive modification:
+ * it uses measured acceleration and measured magnetic field as absolute reference vectors, under the assumption
+ * that measured acceleration will be the local gravity vector.
+ * This is not a reasonable approximation in a rocket: measured acceleration is independent of the Earth's gravity.
+ * 
+ * We'll need to investigate other options for sensor fusion. Even without using the onboard sensor fusion 
+ * algorithm, the MPU9250 appears to be quite a nice chip for our purposes.
+*/
+//#include <quaternionFilters.h> 
+
+#include <Adafruit_FRAM_I2C.h>
+
+// switches, LEDs, and other interfacethings
+const uint8_t SWITCH_PIN = 7;
+
+// define FRAM-related stuff
+Adafruit_FRAM_I2C fram     = Adafruit_FRAM_I2C();
+
+const uint16_t FRAM_CAPACITY_TO_USE = 126;
+const uint16_t FRAM_RESERVED_BYTES = 16; // could be handy I guess?
+
+// define IMU-related stuff
+MPU9250 testIMU;
+const int MPU_9250_int_pin = 2;
+volatile bool MPU_9250_sample_ready = true;
+
+volatile unsigned long MPU_9250_sample_timestamp = micros();
+unsigned long MPU_9250_sample_timestamp_to_write; // I feel like there should be a more elegant way of doing this robustly
+
+//define other useful functions
+void fram_write_int16_t_arr(int16_t vals[], int count, uint16_t start_address) ;
+int16_t fram_read_int16_t(uint16_t start_address);
+
+void mark_MPU9250_sample_ready(void);
+
+void setup() {
+  // Set the serial baud rate to 9600
+  Wire.begin();
+  Serial.begin(38400);     
+
+  // set up interfaces
+  pinMode(SWITCH_PIN, OUTPUT);
+  pinMode(13, OUTPUT);
+
+  // Stolen from example code: test MPU-9250 communications by reading the WHO_AM_I register, then set it to active read mode
+  byte c = testIMU.readByte(MPU9250_ADDRESS, WHO_AM_I_MPU9250);
+  Serial.print("MPU9250 "); Serial.print("I AM "); Serial.print(c, HEX);
+  Serial.print(" I should be "); Serial.println(0x71, HEX);
+  testIMU.initMPU9250();
+  
+  // Stolen from example code: Read the WHO_AM_I register of the magnetometer, this is a good test of
+  // communication. Then set up magnetometer?
+  byte d = testIMU.readByte(AK8963_ADDRESS, WHO_AM_I_AK8963);
+  Serial.print("AK8963 "); Serial.print("I AM "); Serial.print(d, HEX);
+  Serial.print(" I should be "); Serial.println(0x48, HEX);  
+  
+  testIMU.initAK8963(testIMU.magCalibration);
+
+  // set up FRAM
+  Serial.print("attempting to set up FRAM...");
+
+  if (fram.begin())
+  {
+    Serial.println(" success."); 
+  } else {
+    Serial.println(" error.");    
+  }
+
+  for (int ii=0; ii<FRAM_RESERVED_BYTES; ii++)
+  {
+    fram.write8(ii,0); 
+  }
+
+  // set up the interrupt.
+  // remark: this uses external interrupts, but Arduino Uno & friends only have two pins that can do this. Pin change interrupts will be needed for others.
+  pinMode(MPU_9250_int_pin, INPUT); // example sketch claims that this is the correct way to do it 
+  digitalWrite(MPU_9250_int_pin, LOW);
+  attachInterrupt(digitalPinToInterrupt(MPU_9250_int_pin), mark_MPU9250_sample_ready, RISING);
+}
+
+void loop() {
+  int buttonState = digitalRead(SWITCH_PIN);
+  
+   // If button high then log if not dump.
+  if(buttonState) {
+    Serial.println("Reading Sensors and writing to FRAM");
+
+    // Loop around all memory locations.
+    
+    uint16_t ii = FRAM_RESERVED_BYTES-1;
+    while (ii < FRAM_CAPACITY_TO_USE)
+    {
+      
+      /*Serial.print("Int pin status: ");
+      if (digitalRead(MPU_9250_int_pin))
+      {
+        Serial.print("high. "); 
+      } else {
+        Serial.print("low. ");
+      }
+      Serial.print("Sample status: ");
+      if (MPU_9250_sample_ready)
+      {
+        Serial.print("ready. "); 
+      } else {
+        Serial.print("unready. ");
+      }      
+      Serial.print("ii = ");
+      Serial.println(ii);*/
+      
+      if(MPU_9250_sample_ready)
+      {       
+        digitalWrite(13, HIGH);
+        
+        Serial.print("Sample ready at t=");
+        Serial.println(MPU_9250_sample_timestamp_to_write);
+
+        // these are 3×16-bit arrays. 22 bytes per sample. 
+        testIMU.readAccelData(testIMU.accelCount);
+        testIMU.readGyroData(testIMU.gyroCount);
+        testIMU.readMagData(testIMU.magCount);
+        
+        // Under the default settings of the Arduino MPU-9250 library, we clear the interrupt by reading the INT_STATUS register.
+        // This returns a byte which we just discard.
+        testIMU.readByte(MPU9250_ADDRESS, INT_STATUS);        
+        
+        /* Apparently it's necessary to wrap the block below in "noInterrupts".
+         * Otherwise an interrupt might trigger halfway through writing the volatile variables 
+         * which are used by the interrupt and the main subroutine. 
+         * 
+         * This, for obvious reasons, would not be great. 
+         *
+         * (I realised some while after writing this that I could have just kludged it by only clearing the interrupt AFTER this bit,
+         * but oh well, it's good practice.)
+         */
+        noInterrupts(); 
+        MPU_9250_sample_ready = false;
+        MPU_9250_sample_timestamp_to_write = MPU_9250_sample_timestamp;
+        interrupts();
+        
+        fram_write_int16_t_arr(testIMU.accelCount, 3, ii);
+        
+        /*fram.write8(ii,  highbyte(testIMU.accelCount[0]));
+        fram.write8(ii+1,lowbyte(testIMU.accelCount[0]);
+        fram.write8(ii+2,highbyte(testIMU.accelCount[1]));
+        fram.write8(ii+3,lowbyte(testIMU.accelCount[1]));
+        fram.write8(ii+4,highbyte(testIMU.accelCount[2]));
+        fram.write8(ii+5,lowbyte(testIMU.accelCount[2]));*/
+
+        ii+=6;
+
+        fram_write_int16_t_arr(testIMU.gyroCount, 3, ii);
+        
+        /*fram.write8(ii,  testIMU.gyroCount[0] >> 8);
+        fram.write8(ii+1,testIMU.gyroCount[0]);
+        fram.write8(ii+2,testIMU.gyroCount[1] >> 8);
+        fram.write8(ii+3,testIMU.gyroCount[1]);
+        fram.write8(ii+4,testIMU.gyroCount[2] >> 8);
+        fram.write8(ii+5,testIMU.gyroCount[2]);*/
+
+        ii+=6;
+
+        fram_write_int16_t_arr(testIMU.magCount, 3, ii);
+
+        /*fram.write8(ii,  testIMU.magCount[0] >> 8);
+        fram.write8(ii+1,testIMU.magCount[0]);
+        fram.write8(ii+2,testIMU.magCount[1] >> 8);
+        fram.write8(ii+3,testIMU.magCount[1]);
+        fram.write8(ii+4,testIMU.magCount[2] >> 8);
+        fram.write8(ii+5,testIMU.magCount[2]);*/
+
+        ii+=6;
+
+        /*Serial.print("Timestamp is ");
+        Serial.print(MPU_9250_sample_timestamp_to_write);
+        Serial.print(" (");*/
+        
+        
+        
+        for (uint16_t jj=0; jj<4; jj++)
+        {
+           //Serial.print(((MPU_9250_sample_timestamp_to_write >> 8*(3-jj)) & 0x000000FFUL));
+           //Serial.print(", ");
+           
+           fram.write8(ii+jj, (uint8_t) ((MPU_9250_sample_timestamp_to_write >> 8*(3-jj)) & 0x000000FFUL));
+        }
+        //Serial.println(")");
+       
+        ii+=4;
+       
+        digitalWrite(13, LOW); 
+      }
+    }
+
+    Serial.println("Filled memory, starting again?");
+  } else {    
+    uint16_t ii = FRAM_RESERVED_BYTES - 1;
+    
+    int16_t value;
+    unsigned long timestamp;
+    
+    // Dump FRAM here to the serial port.
+    while (ii < FRAM_CAPACITY_TO_USE + FRAM_RESERVED_BYTES) {
+      timestamp = 0;
+      
+      //HEX DUMP MODE - was useful for debugging
+      /*Serial.print(fram.read8(ii), HEX);
+      Serial.print(" ");
+      ii++;
+      
+      if (((ii-FRAM_RESERVED_BYTES) % 22) == 0)
+     {
+       Serial.println(" ");
+     } */
+      
+      //RAW SAMPLE DUMP MODE - somewhat more readable. Not in any physical units.
+      Serial.print("New sample! ii = ");
+      Serial.println(ii);
+      for (uint16_t jj = 0; jj<9; jj++)
+      {
+        // bunch of magic numbers here, not great.
+        value = fram_read_int16_t(ii+2*jj);
+        Serial.print(value);
+        Serial.print(", ");
+      }
+      Serial.print("t = ");
+      
+      ii+=18;
+      
+      Serial.print("(");
+      for (uint16_t jj = 0; jj<4; jj++)
+      {
+        timestamp = timestamp << 8;
+        Serial.print(fram.read8(ii+jj));
+        Serial.print(", ");
+        timestamp |= (unsigned long) (fram.read8(ii+jj));        
+      }
+      Serial.print(") ");
+      Serial.println(timestamp);
+      
+      ii+=4;
+    }
+
+    // Stop running until Arduino is reset.
+    exit(0);
+  }
+}
+
+void mark_MPU9250_sample_ready(void) {
+  MPU_9250_sample_ready = true;
+  MPU_9250_sample_timestamp = micros();
+}
+
+void fram_write_int16_t_arr(int16_t vals[], int count, uint16_t start_address) {
+  for (int ii=0; ii<count; ii++)
+  {
+    fram.write8(start_address+2*ii, highByte(vals[ii]));        
+    fram.write8(start_address+2*ii+1, lowByte(vals[ii]));
+  }
+}
+
+int16_t fram_read_int16_t(uint16_t start_address) {
+    int16_t temp_read_num = ((int16_t) (fram.read8(start_address))) << 8;
+    temp_read_num |= (int16_t) fram.read8(start_address+1);
+    return temp_read_num;
+}

--- a/mpu-9250-tests.ino
+++ b/mpu-9250-tests.ino
@@ -98,23 +98,6 @@ void loop() {
     while (ii < FRAM_CAPACITY_TO_USE)
     {
       
-      /*Serial.print("Int pin status: ");
-      if (digitalRead(MPU_9250_int_pin))
-      {
-        Serial.print("high. "); 
-      } else {
-        Serial.print("low. ");
-      }
-      Serial.print("Sample status: ");
-      if (MPU_9250_sample_ready)
-      {
-        Serial.print("ready. "); 
-      } else {
-        Serial.print("unready. ");
-      }      
-      Serial.print("ii = ");
-      Serial.println(ii);*/
-      
       if(MPU_9250_sample_ready)
       {       
         digitalWrite(13, HIGH);
@@ -145,61 +128,27 @@ void loop() {
         MPU_9250_sample_timestamp_to_write = MPU_9250_sample_timestamp;
         interrupts();
         
+        // Write the samples to FRAM 
         fram_write_int16_t_arr(testIMU.accelCount, 3, ii);
-        
-        /*fram.write8(ii,  highbyte(testIMU.accelCount[0]));
-        fram.write8(ii+1,lowbyte(testIMU.accelCount[0]);
-        fram.write8(ii+2,highbyte(testIMU.accelCount[1]));
-        fram.write8(ii+3,lowbyte(testIMU.accelCount[1]));
-        fram.write8(ii+4,highbyte(testIMU.accelCount[2]));
-        fram.write8(ii+5,lowbyte(testIMU.accelCount[2]));*/
-
         ii+=6;
-
         fram_write_int16_t_arr(testIMU.gyroCount, 3, ii);
-        
-        /*fram.write8(ii,  testIMU.gyroCount[0] >> 8);
-        fram.write8(ii+1,testIMU.gyroCount[0]);
-        fram.write8(ii+2,testIMU.gyroCount[1] >> 8);
-        fram.write8(ii+3,testIMU.gyroCount[1]);
-        fram.write8(ii+4,testIMU.gyroCount[2] >> 8);
-        fram.write8(ii+5,testIMU.gyroCount[2]);*/
-
         ii+=6;
-
         fram_write_int16_t_arr(testIMU.magCount, 3, ii);
-
-        /*fram.write8(ii,  testIMU.magCount[0] >> 8);
-        fram.write8(ii+1,testIMU.magCount[0]);
-        fram.write8(ii+2,testIMU.magCount[1] >> 8);
-        fram.write8(ii+3,testIMU.magCount[1]);
-        fram.write8(ii+4,testIMU.magCount[2] >> 8);
-        fram.write8(ii+5,testIMU.magCount[2]);*/
-
         ii+=6;
 
-        /*Serial.print("Timestamp is ");
-        Serial.print(MPU_9250_sample_timestamp_to_write);
-        Serial.print(" (");*/
-        
-        
-        
+        //  Also write timestamp to FRAM
         for (uint16_t jj=0; jj<4; jj++)
         {
-           //Serial.print(((MPU_9250_sample_timestamp_to_write >> 8*(3-jj)) & 0x000000FFUL));
-           //Serial.print(", ");
-           
            fram.write8(ii+jj, (uint8_t) ((MPU_9250_sample_timestamp_to_write >> 8*(3-jj)) & 0x000000FFUL));
-        }
-        //Serial.println(")");
-       
+        }       
         ii+=4;
        
+        // 200 Hz is far too fast to see, so it'll just look like the LED is on when samples are being read
         digitalWrite(13, LOW); 
       }
     }
 
-    Serial.println("Filled memory, starting again?");
+    Serial.println("Filled FRAM, starting again?");
   } else {    
     uint16_t ii = FRAM_RESERVED_BYTES - 1;
     


### PR DESCRIPTION
MPU-9250 tests: using interrupts to get exact sample time, read raw values from accelerometer, magnetometer and gyroscope, and write them along with a time stamp to the FRAM. 

Currently does this at 200 Hz. See Trello comments for the thrilling story of how I debugged the code.

Includes a modified version of the Adafruit I²C FRAM driver. Seemed like the easiest approach.